### PR TITLE
Using the CVMFS certs as default for EGI access to LIGO caches

### DIFF
--- a/etc/cvmfs/config.d/ligo.osgstorage.org.conf
+++ b/etc/cvmfs/config.d/ligo.osgstorage.org.conf
@@ -9,3 +9,4 @@ CVMFS_AUTHZ_HELPER=
 X509_CERT_DIR=
 source $CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/libexec/osgstorage-auth.conf
 CVMFS_MAX_RETRIES=0
+X509_CERT_DIR=/cvmfs/oasis.opensciencegrid.org/mis/certificates


### PR DESCRIPTION
This would help us have it as default that EGI access uses the CVMFS cert bundle. This will help us a lot and if sites want it they can all always override it.

@DrDaveD, @zvada  what are your thoughts?