### PR TITLE
Set fallback proxies only if domain is known

### DIFF
--- a/etc/cvmfs/common.conf
+++ b/etc/cvmfs/common.conf
@@ -1,4 +1,3 @@
 if [ -n "$CVMFS_HTTP_PROXY" ] && [ "$CVMFS_HTTP_PROXY" != "DIRECT" ] && [ "$CVMFS_HTTP_PROXY" != "auto;DIRECT" ]; then
   CVMFS_FALLBACK_PROXY="http://cvmfsbproxy.cern.ch:3126;http://cvmfsbproxy.fnal.gov:3126"
 fi
-

--- a/etc/cvmfs/domain.d/cern.ch.conf
+++ b/etc/cvmfs/domain.d/cern.ch.conf
@@ -1,3 +1,4 @@
+. $CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/common.conf
 if [ "$CVMFS_HTTP_PROXY" = "DIRECT" ] || [ "$CVMFS_HTTP_PROXY" = "auto;DIRECT" ]; then
     CVMFS_SERVER_URL="http://s1cern-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io/cvmfs/@fqrn@"
 else

--- a/etc/cvmfs/domain.d/egi.eu.conf
+++ b/etc/cvmfs/domain.d/egi.eu.conf
@@ -1,3 +1,4 @@
+. $CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/common.conf
 if [ "$CVMFS_HTTP_PROXY" = "DIRECT" ] || [ "$CVMFS_HTTP_PROXY" = "auto;DIRECT" ]; then
     CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1triumf-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io/cvmfs/@fqrn@"
 else

--- a/etc/cvmfs/domain.d/gridpp.ac.uk.conf
+++ b/etc/cvmfs/domain.d/gridpp.ac.uk.conf
@@ -1,3 +1,4 @@
+. $CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/common.conf
 if [ "$CVMFS_HTTP_PROXY" = "DIRECT" ] || [ "$CVMFS_HTTP_PROXY" = "auto;DIRECT" ]; then
     CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@"
 else

--- a/etc/cvmfs/domain.d/lsst.eu.conf
+++ b/etc/cvmfs/domain.d/lsst.eu.conf
@@ -1,2 +1,3 @@
+. $CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/common.conf
 CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch:8000/cvmfs/@fqrn@;http://cclssts1.in2p3.fr/cvmfs/@fqrn@"
 CVMFS_PUBLIC_KEY="$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/lsst.eu.pub"

--- a/etc/cvmfs/domain.d/opensciencegrid.org.conf
+++ b/etc/cvmfs/domain.d/opensciencegrid.org.conf
@@ -1,3 +1,4 @@
+. $CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/common.conf
 if [ "$CVMFS_HTTP_PROXY" = "DIRECT" ] || [ "$CVMFS_HTTP_PROXY" = "auto;DIRECT" ]; then
     CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io/cvmfs/@fqrn@"
 else

--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -1,3 +1,4 @@
+. $CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/common.conf
 if [ "$CVMFS_HTTP_PROXY" = "DIRECT" ] || [ "$CVMFS_HTTP_PROXY" = "auto;DIRECT" ]; then
     CVMFS_SERVER_URL="http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1osggoc-cvmfs.openhtc.io/cvmfs/@fqrn@"
 else

--- a/etc/cvmfs/domain.d/skatelescope.eu.conf
+++ b/etc/cvmfs/domain.d/skatelescope.eu.conf
@@ -1,2 +1,3 @@
+. $CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/common.conf
 CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@"
 CVMFS_PUBLIC_KEY="$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/skatelescope.eu.pub"


### PR DESCRIPTION
Instead of applying fallback proxies in default.conf for all domains, source common.conf only for domains known to the configuration repo.