### PR TITLE
Select cloudflare servers also with proxy of "auto;DIRECT"

### DIFF
--- a/etc/cvmfs/default.conf
+++ b/etc/cvmfs/default.conf
@@ -1,4 +1,4 @@
-if [ "$CVMFS_HTTP_PROXY" = "DIRECT" ]; then
+if [ "$CVMFS_HTTP_PROXY" = "DIRECT" ] || [ "$CVMFS_HTTP_PROXY" = "auto;DIRECT" ]; then
     CVMFS_SERVER_URL="http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1osggoc-cvmfs.openhtc.io/cvmfs/@fqrn@"
     CVMFS_FALLBACK_PROXY=""
 else


### PR DESCRIPTION
I happened to notice that this was missing from the osg default.conf, even though it was already there for everywhere else CVMFS_SERVER_URL was set, both in the osg and egi config repos.