### PR TITLE
Merge osg pr #25 into egi config

### DIFF
--- a/libexec/osgstorage-auth.conf
+++ b/libexec/osgstorage-auth.conf
@@ -28,16 +28,23 @@ if [ ! -f /etc/grid-security/certificates/cilogon-basic.pem ] || \
         ! $CVMFS_X509_AUTHZ_LIBS_VALID; then
     # Get at least CA certs and voms info files from the oasis repo
 
-    CVMFS_AUTHZ_OSG_BASE_DIR="$CVMFS_MOUNT_DIR/oasis.opensciencegrid.org/mis/osg-wn-client/current"
+    OSGBASEDIR="$CVMFS_MOUNT_DIR/oasis.opensciencegrid.org/mis/osg-wn-client"
     if $CVMFS_X509_AUTHZ_LIBS_VALID; then
         # the needed libraries are already installed
         # we'll only use portable files, so pick any osg-wn-client
-        CVMFS_AUTHZ_OSG_BASE_DIR="$CVMFS_AUTHZ_OSG_BASE_DIR/el7-x86_64"
+        CVMFS_AUTHZ_OSG_BASE_DIR="$OSGBASEDIR/current/el7-x86_64"
         X509_CERT_DIR=$CVMFS_AUTHZ_OSG_BASE_DIR/etc/grid-security/certificates
     else
         # we'll use both libraries and portable files
         # only Redhat Enterprise Linux or derivatives are supported
-        CVMFS_AUTHZ_OSG_WN_CLIENT="$CVMFS_AUTHZ_OSG_BASE_DIR/el`distroversion|cut -d. -f1`-`arch`"
+        DISTROVERSION="`distroversion|cut -d. -f1`"
+        DISTROARCH="`arch`"
+        OSGRELEASE=current
+        if [ "$DISTROVERSION" = 6 ]; then
+            # choose last OSG release to support el6
+            OSGRELEASE=3.4/current
+        fi
+        CVMFS_AUTHZ_OSG_WN_CLIENT="$OSGBASEDIR/$OSGRELEASE/el$DISTROVERSION-$DISTROARCH"
         X509_CERT_DIR=$CVMFS_AUTHZ_OSG_WN_CLIENT/etc/grid-security/certificates
     fi
 else


### PR DESCRIPTION
Hardens ligo.osgstorage.org configuration so that el6 systems without full libraries will be able to still find osg libraries after the "current" link moves from osg 3.4 to 3.5 releases.