### PR TITLE
Enable cvmfs dns roaming by default

### DIFF
--- a/etc/cvmfs/default.conf
+++ b/etc/cvmfs/default.conf
@@ -4,3 +4,6 @@ if [ "$CVMFS_HTTP_PROXY" = "DIRECT" ] || [ "$CVMFS_HTTP_PROXY" = "auto;DIRECT" ]
 else
     CVMFS_SERVER_URL="http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1goc.opensciencegrid.org:8000/cvmfs/@fqrn@"
 fi
+
+# Automatically detect DNS nameserver changes
+CVMFS_DNS_ROAMING=on


### PR DESCRIPTION
This is not urgent but let's include it the next time there's an update, to keep in sync with the default branch.