### PR TITLE
Enable cvmfs dns roaming by default

### DIFF
--- a/etc/cvmfs/default.conf
+++ b/etc/cvmfs/default.conf
@@ -1,0 +1,2 @@
+# Automatically detect DNS nameserver changes
+CVMFS_DNS_ROAMING=on


### PR DESCRIPTION
This is not urgent but let's add it the next time there is an update needed to the config repo, to keep more in sync with the default branch.