### PR TITLE
Remove sc-cache.chtc.wisc.edu

### DIFF
--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -9,7 +9,7 @@ else
 fi
 
 
-CVMFS_EXTERNAL_URL="http://stashcache.t2.ucsd.edu:8000/;http://mwt2-stashcache.campuscluster.illinois.edu:8000/;http://its-condor-xrootd1.syr.edu:8000/;http://osg-kansas-city-stashcache.nrp.internet2.edu:8000/;http://osg-chicago-stashcache.nrp.internet2.edu:8000/;http://osg-new-york-stashcache.nrp.internet2.edu:8000/;http://sc-cache.chtc.wisc.edu:8000/;http://osg-gftp2.pace.gatech.edu:8000/;http://dtn2-daejeon.kreonet.net:8000/;http://osg-houston-stashcache.nrp.internet2.edu:8000/;http://osg-sunnyvale-stashcache.nrp.internet2.edu:8000/"
+CVMFS_EXTERNAL_URL="http://stashcache.t2.ucsd.edu:8000/;http://mwt2-stashcache.campuscluster.illinois.edu:8000/;http://its-condor-xrootd1.syr.edu:8000/;http://osg-kansas-city-stashcache.nrp.internet2.edu:8000/;http://osg-chicago-stashcache.nrp.internet2.edu:8000/;http://osg-new-york-stashcache.nrp.internet2.edu:8000/;http://osg-gftp2.pace.gatech.edu:8000/;http://dtn2-daejeon.kreonet.net:8000/;http://osg-houston-stashcache.nrp.internet2.edu:8000/;http://osg-sunnyvale-stashcache.nrp.internet2.edu:8000/"
 CVMFS_EXTERNAL_MAX_SERVERS=4
 CVMFS_FOLLOW_REDIRECTS=yes
 CVMFS_QUOTA_LIMIT=1000


### PR DESCRIPTION
The CHTC cache is underpowered and should only be used for local jobs.