### PR TITLE
Set CVMFS_FALLBACK_PROXY in case common.conf sets it

### DIFF
--- a/etc/cvmfs/domain.d/cern.ch.conf
+++ b/etc/cvmfs/domain.d/cern.ch.conf
@@ -1,4 +1,6 @@
+# These are here so cvmfs will notice them if common.conf sets them
 CVMFS_HTTP_PROXY="$CVMFS_HTTP_PROXY"
+CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 . ../common.conf
 
 # The cvmfs-config-default package has this variable turned off by default.

--- a/etc/cvmfs/domain.d/egi.eu.conf
+++ b/etc/cvmfs/domain.d/egi.eu.conf
@@ -1,4 +1,6 @@
+# These are here so cvmfs will notice them if common.conf sets them
 CVMFS_HTTP_PROXY="$CVMFS_HTTP_PROXY"
+CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 . ../common.conf
 
 # The cvmfs-config-default package has this variable turned off by default.

--- a/etc/cvmfs/domain.d/hsf.org.conf
+++ b/etc/cvmfs/domain.d/hsf.org.conf
@@ -1,4 +1,6 @@
+# These are here so cvmfs will notice them if common.conf sets them
 CVMFS_HTTP_PROXY="$CVMFS_HTTP_PROXY"
+CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 . ../common.conf
 
 # The cvmfs-config-default package has this variable turned off by default.

--- a/etc/cvmfs/domain.d/opensciencegrid.org.conf
+++ b/etc/cvmfs/domain.d/opensciencegrid.org.conf
@@ -1,4 +1,6 @@
+# These are here so cvmfs will notice them if common.conf sets them
 CVMFS_HTTP_PROXY="$CVMFS_HTTP_PROXY"
+CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 . ../common.conf
 
 # The cvmfs-config-default package has this variable turned off by default.


### PR DESCRIPTION
These settings were left out, and cvmfs currently doesn't notice when CVMFS_FALLBACK_PROXY is set in common.conf.