### PR TITLE
Put FNAL fallback proxy first before CERN fallback proxy

### DIFF
--- a/etc/cvmfs/common.conf
+++ b/etc/cvmfs/common.conf
@@ -22,5 +22,8 @@ if [ "$CVMFS_USE_CDN" != "yes" ] && [ "$CVMFS_CLIENT_PROFILE" != "custom" ]; the
   # If not turned off through the use of CDN or a "custom" profile, we set
   #  a fallback proxy so that failing site proxies can be detected while
   #  still allowing cvmfs access at reduced performance.
-  CVMFS_FALLBACK_PROXY="http://cvmfsbproxy.cern.ch:3126;http://cvmfsbproxy.fnal.gov:3126"
+  # These get sorted geographically, but a bug prevents that sorted order
+  #  from taking effect immediately when there's no functioning local squid.
+  #  See https://sft.its.cern.ch/jira/browse/CVM-1920
+  CVMFS_FALLBACK_PROXY="http://cvmfsbproxy.fnal.gov:3126;http://cvmfsbproxy.cern.ch:3126"
 fi


### PR DESCRIPTION
For reason why see [CVM-1920](https://sft.its.cern.ch/jira/browse/CVM-1920)