### PR TITLE
Add osgstorage.org symlink to opensciencegrid.org

### DIFF
--- a/etc/cvmfs/keys/osgstorage.org/opensciencegrid.org.pub
+++ b/etc/cvmfs/keys/osgstorage.org/opensciencegrid.org.pub
@@ -1,0 +1,1 @@
+opensciencegrid.org/opensciencegrid.org.pub


### PR DESCRIPTION
I'm adding this osgstorage.org key symlink for the manage-replicas tool which is getting a new option to automatically download domain keys from github.