### PR TITLE
Repair osgstorage symlink

### DIFF
--- a/etc/cvmfs/keys/osgstorage.org/opensciencegrid.org.pub
+++ b/etc/cvmfs/keys/osgstorage.org/opensciencegrid.org.pub
@@ -1,1 +1,1 @@
-opensciencegrid.org/opensciencegrid.org.pub
+../opensciencegrid.org/opensciencegrid.org.pub


### PR DESCRIPTION
The old one was pointing to a non-existent place