### PR TITLE
Add support for unprotected osgstorage repositories in default

### DIFF
--- a/etc/cvmfs/domain.d/opensciencegrid.org.conf
+++ b/etc/cvmfs/domain.d/opensciencegrid.org.conf
@@ -10,6 +10,6 @@ if [ "$CVMFS_USE_CDN" = "yes" ]; then
 else
     CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@"
 fi
-CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/osgstorage.org
+CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/opensciencegrid.org
 CVMFS_USE_GEOAPI=yes
 CVMFS_SEND_INFO_HEADER=yes

--- a/etc/cvmfs/domain.d/opensciencegrid.org.conf
+++ b/etc/cvmfs/domain.d/opensciencegrid.org.conf
@@ -10,6 +10,6 @@ if [ "$CVMFS_USE_CDN" = "yes" ]; then
 else
     CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@"
 fi
-CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/opensciencegrid.org
+CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/osgstorage.org
 CVMFS_USE_GEOAPI=yes
 CVMFS_SEND_INFO_HEADER=yes

--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -9,7 +9,7 @@ if [ "$CVMFS_USE_CDN" = "yes" ]; then
 else
     CVMFS_SERVER_URL="http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1goc.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@"
 fi
-CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/opensciencegrid.org
+CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/osgstorage.org
 
 CVMFS_EXTERNAL_URL="http://stashcache.t2.ucsd.edu:8000/;http://osg-kansas-city-stashcache.nrp.internet2.edu:8000/;http://osg-new-york-stashcache.nrp.internet2.edu:8000/;http://dtn2-daejeon.kreonet.net:8000/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://fiona.uvalight.net:8000/;http://stashcache.gravity.cf.ac.uk:8000/;http://xcache.cr.cnaf.infn.it:8000/;http://xcachevirgo.pic.es:8000/"

--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -1,0 +1,20 @@
+# These are here so cvmfs will notice them if common.conf sets them
+CVMFS_USE_CDN="$CVMFS_USE_CDN"
+CVMFS_HTTP_PROXY="$CVMFS_HTTP_PROXY"
+CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
+. ../common.conf
+
+if [ "$CVMFS_USE_CDN" = "yes" ]; then
+    CVMFS_SERVER_URL="http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1osggoc-cvmfs.openhtc.io/cvmfs/@fqrn@"
+else
+    CVMFS_SERVER_URL="http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1goc.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@"
+fi
+CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/opensciencegrid.org
+
+CVMFS_EXTERNAL_URL="http://stashcache.t2.ucsd.edu:8000/;http://osg-kansas-city-stashcache.nrp.internet2.edu:8000/;http://osg-new-york-stashcache.nrp.internet2.edu:8000/;http://dtn2-daejeon.kreonet.net:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://fiona.uvalight.net:8000/;http://stashcache.gravity.cf.ac.uk:8000/;http://xcache.cr.cnaf.infn.it:8000/;http://xcachevirgo.pic.es:8000/"
+CVMFS_EXTERNAL_MAX_SERVERS=4
+CVMFS_FOLLOW_REDIRECTS=yes
+CVMFS_QUOTA_LIMIT=1000
+CVMFS_CACHE_BASE="$CVMFS_CACHE_BASE/osgstorage"
+CVMFS_LOW_SPEED_LIMIT=512

--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -5,9 +5,9 @@ CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 . ../common.conf
 
 if [ "$CVMFS_USE_CDN" = "yes" ]; then
-    CVMFS_SERVER_URL="http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1osggoc-cvmfs.openhtc.io/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1osggoc-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io/cvmfs/@fqrn@"
 else
-    CVMFS_SERVER_URL="http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1goc.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1goc.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@"
 fi
 CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/osgstorage.org
 

--- a/etc/cvmfs/keys/osgstorage.org/opensciencegrid.org.pub
+++ b/etc/cvmfs/keys/osgstorage.org/opensciencegrid.org.pub
@@ -1,0 +1,1 @@
+../opensciencegrid.org/opensciencegrid.org.pub


### PR DESCRIPTION
Adds the common osgstorage.org configuration to the default branch without the specializations for protected repositories.  In particular, this should give CernVM users access to dune.osgstorage.org

It uses the EGI version of osgstorage.org