### PR TITLE
Changes for supporting ligo.osgstorage.org in cvmfsexec

### DIFF
--- a/libexec/authz/cvmfs_scitoken_helper
+++ b/libexec/authz/cvmfs_scitoken_helper
@@ -8,8 +8,8 @@ elif [ -n "$OSG_BASE_DIR" ]; then
     export X509_VOMS_DIR=$OSG_BASE_DIR/etc/grid-security/vomsdir
     export VOMS_USERCONF=$OSG_BASE_DIR/etc/vomses
 fi
-if [ -x /usr/libexec/cvmfs/authz/cvmfs_scitoken_helper ];then
-    exec /usr/libexec/cvmfs/authz/cvmfs_scitoken_helper "$@"
+if [ -x $CVMFS_DIST/usr/libexec/cvmfs/authz/cvmfs_scitoken_helper ];then
+    $CVMFS_DIST/usr/libexec/cvmfs/authz/cvmfs_scitoken_helper "$@"
 fi
 # this would be used if cvmfs-x509-helper rpm version is < 2.0
-exec /usr/libexec/cvmfs/authz/cvmfs_x509_helper "$@"
+exec $CVMFS_DIST/usr/libexec/cvmfs/authz/cvmfs_x509_helper "$@"

--- a/libexec/authz/cvmfs_x509_helper
+++ b/libexec/authz/cvmfs_x509_helper
@@ -6,5 +6,4 @@ elif [ -n "$OSG_BASE_DIR" ]; then
     export X509_VOMS_DIR=$OSG_BASE_DIR/etc/grid-security/vomsdir
     export VOMS_USERCONF=$OSG_BASE_DIR/etc/vomses
 fi
-exec /usr/libexec/cvmfs/authz/cvmfs_x509_helper "$@"
-
+exec $CVMFS_DIST/usr/libexec/cvmfs/authz/cvmfs_x509_helper "$@"

--- a/libexec/osgstorage-auth.conf
+++ b/libexec/osgstorage-auth.conf
@@ -14,7 +14,9 @@ distroversion()
     #   on systems that have /etc/os-release
     if [ -f /etc/os-release ]; then
         # If this function is moved back under etc/cvmfs so it is
-        #   parsed by cvmfs, the '=' will confuse the parser.
+        #   parsed by cvmfs, the '=' will confuse the parser in
+        #   cvmfs versions <= 2.8.1.  Note that under cvmfsexec
+        #   this function does get parsed.
         sed -n 's/"//g;s/^VERSION_ID=//p' /etc/os-release
     else
         lsb_release -rs
@@ -30,12 +32,13 @@ if [ ! -f /etc/grid-security/certificates/cilogon-basic.pem ] || \
         ! $CVMFS_X509_AUTHZ_LIBS_VALID; then
     # Get at least CA certs and voms info files from the oasis repo
 
-    OSGBASEDIR="$CVMFS_MOUNT_DIR/oasis.opensciencegrid.org/mis/osg-wn-client"
+    OSGMISDIR="$CVMFS_MOUNT_DIR/oasis.opensciencegrid.org/mis"
+    OSGBASEDIR="$OSGMISDIR/osg-wn-client"
+    X509_CERT_DIR=$OSGMISDIR/certificates
     if $CVMFS_X509_AUTHZ_LIBS_VALID; then
         # the needed libraries are already installed
         # we'll only use portable files, so pick any osg-wn-client
         CVMFS_AUTHZ_OSG_BASE_DIR="$OSGBASEDIR/current/el7-x86_64"
-        X509_CERT_DIR=$CVMFS_AUTHZ_OSG_BASE_DIR/etc/grid-security/certificates
     else
         # we'll use both libraries and portable files
         # only Redhat Enterprise Linux or derivatives are supported
@@ -47,7 +50,6 @@ if [ ! -f /etc/grid-security/certificates/cilogon-basic.pem ] || \
             OSGRELEASE=3.4/current
         fi
         CVMFS_AUTHZ_OSG_WN_CLIENT="$OSGBASEDIR/$OSGRELEASE/el$DISTROVERSION-$DISTROARCH"
-        X509_CERT_DIR=$CVMFS_AUTHZ_OSG_WN_CLIENT/etc/grid-security/certificates
     fi
 else
     # this is needed because cvmfs would otherwise set this to an empty


### PR DESCRIPTION
These changes are part of what's needed to get ligo.osgstorage.org to be mountable under cvmfsexec.  It also needs a current nightly build of cvmfs (or version 2.8.2 when it is released, or greater later) and cvmfsexec version 4.12 (or greater).