### PR TITLE
Remove obsolete Illinois cache

### DIFF
--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -16,7 +16,7 @@ CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/osgstora
 
 
 # stashcache servers configured by OSG
-CVMFS_EXTERNAL_URL="http://stashcache.t2.ucsd.edu:8000/;http://mwt2-stashcache.campuscluster.illinois.edu:8000/;http://its-condor-xrootd1.syr.edu:8000/;http://osg-kansas-city-stashcache.nrp.internet2.edu:8000/;http://osg-chicago-stashcache.nrp.internet2.edu:8000/;http://osg-new-york-stashcache.nrp.internet2.edu:8000/;http://stash-cache.osg.chtc.io:8000/;http://osg-gftp2.pace.gatech.edu:8000/;http://dtn2-daejeon.kreonet.net:8000/;http://osg-houston-stashcache.nrp.internet2.edu:8000/;http://osg-sunnyvale-stashcache.nrp.internet2.edu:8000/"
+CVMFS_EXTERNAL_URL="http://stashcache.t2.ucsd.edu:8000/;http://its-condor-xrootd1.syr.edu:8000/;http://osg-kansas-city-stashcache.nrp.internet2.edu:8000/;http://osg-chicago-stashcache.nrp.internet2.edu:8000/;http://osg-new-york-stashcache.nrp.internet2.edu:8000/;http://stash-cache.osg.chtc.io:8000/;http://osg-gftp2.pace.gatech.edu:8000/;http://dtn2-daejeon.kreonet.net:8000/;http://osg-houston-stashcache.nrp.internet2.edu:8000/;http://osg-sunnyvale-stashcache.nrp.internet2.edu:8000/"
 # extra stashcache servers not used by OSG
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://fiona.uvalight.net:8000/;http://stashcache.gravity.cf.ac.uk:8000/;http://xcache.cr.cnaf.infn.it:8000/;http://xcachevirgo.pic.es:8000/"
 CVMFS_EXTERNAL_MAX_SERVERS=4


### PR DESCRIPTION
Merge pr #78 into master - The MWT2 admins have shutdown the Illinois cache in favor of the one in Internet2.