### PR TITLE
Use CVMFS_MAGIC_XATTRS_VISIBILITY

### DIFF
--- a/etc/cvmfs/default.conf
+++ b/etc/cvmfs/default.conf
@@ -15,4 +15,7 @@ CVMFS_CONFIG_REPO_DEFAULT_ENV=1
 # extended  attributes ('pid', 'host', etc.) to be copied up.
 # Note that the magic xattrs are still available when explicitly requested
 # (attr -g ...), they are just not listed (attr -l ...)
+# For cvmfs < 2.9.1
 CVMFS_HIDE_MAGIC_XATTRS=yes
+# For cvmfs >= 2.9.1
+CVMFS_MAGIC_XATTRS_VISIBILITY=rootonly

--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -20,4 +20,7 @@ CVMFS_CACHE_BASE="$CVMFS_CACHE_BASE/osgstorage"
 CVMFS_LOW_SPEED_LIMIT=512
 
 # For pure data repositories, we can safely expose the synthetic xattrs
+# For cvmfs < 2.9.1
 CVMFS_HIDE_MAGIC_XATTRS=no
+# For cvmfs >= 2.9.1
+CVMFS_MAGIC_XATTRS_VISIBILITY=always


### PR DESCRIPTION
Cvmfs >= 2.9.1 has support for more fine-grained visibility settings for synthetic extended attributes (see [CVM-2058](https://sft.its.cern.ch/jira/browse/CVM-2058)). Use the new option for new clients while keeping the old one for older clients.