### PR TITLE
Hide magic extended attributes when possible

### DIFF
--- a/etc/cvmfs/default.conf
+++ b/etc/cvmfs/default.conf
@@ -11,3 +11,11 @@ fi
 # Clear out default setting from cvmfs-config-osg rpm's default.d file so
 #   it doesn't apply to locally-configured repositories
 CVMFS_FALLBACK_PROXY=""
+
+# cvmfs synthetic extended attributes ('pid', 'host', etc.) can interfere
+# with python shutil.copy2 and overlayFS when applied to files, so make
+# the attributes visible only on the root directory by default when possible.
+# Note that the magic xattrs are still available when explicitly requested
+# (attr -g ...), they are just not listed (attr -l ...).
+# For cvmfs >= 2.9.1
+CVMFS_MAGIC_XATTRS_VISIBILITY=rootonly


### PR DESCRIPTION
cvmfs-2.9.1 adds new option CVMFS_MAGIC_XATTRS_VISIBILITY=rootonly but it is not default so enable it for use when available.

Compare to #83 which also sets this but leaves also CVMFS_HIDE_MAGIC_XATTRS=yes to hide all magic extended attributes for all older releases in the default configuration.  I'm worried that will break scripts that are explicitly looking for extended attributes, which they typically do on the root directory, so I have not enabled that for osg.