### PR TITLE
Use osg 3.5 wn-client instead of current for LIGO cvmfs-x509-helper libraries

### DIFF
--- a/libexec/osgstorage-auth.conf
+++ b/libexec/osgstorage-auth.conf
@@ -44,9 +44,12 @@ if [ ! -f /etc/grid-security/certificates/cilogon-basic.pem ] || \
         # only Redhat Enterprise Linux or derivatives are supported
         DISTROVERSION="`distroversion|cut -d. -f1`"
         DISTROARCH="`arch`"
-        OSGRELEASE=current
+        # OSGRELEASE=current
+        # choose the release that includes GSI libraries, until LIGO
+        #   is completely switched over to tokens
+        OSGRELEASE=3.5/current
         if [ "$DISTROVERSION" = 6 ]; then
-            # choose last OSG release to support el6
+            # choose the last OSG release to support el6
             OSGRELEASE=3.4/current
         fi
         CVMFS_AUTHZ_OSG_WN_CLIENT="$OSGBASEDIR/$OSGRELEASE/el$DISTROVERSION-$DISTROARCH"


### PR DESCRIPTION
As discussed in [SOFTWARE-4799](https://opensciencegrid.atlassian.net/browse/SOFTWARE-4799)