### PR TITLE
Update libexec interface for LIGO 

### DIFF
--- a/libexec/authz/cvmfs_scitoken_helper
+++ b/libexec/authz/cvmfs_scitoken_helper
@@ -9,7 +9,7 @@ elif [ -n "$OSG_BASE_DIR" ]; then
     export VOMS_USERCONF=$OSG_BASE_DIR/etc/vomses
 fi
 if [ -x $CVMFS_DIST/usr/libexec/cvmfs/authz/cvmfs_scitoken_helper ];then
-    $CVMFS_DIST/usr/libexec/cvmfs/authz/cvmfs_scitoken_helper "$@"
+    exec $CVMFS_DIST/usr/libexec/cvmfs/authz/cvmfs_scitoken_helper "$@"
 fi
 # this would be used if cvmfs-x509-helper rpm version is < 2.0
 exec $CVMFS_DIST/usr/libexec/cvmfs/authz/cvmfs_x509_helper "$@"

--- a/libexec/osgstorage-auth.conf
+++ b/libexec/osgstorage-auth.conf
@@ -44,9 +44,12 @@ if [ ! -f /etc/grid-security/certificates/cilogon-basic.pem ] || \
         # only Redhat Enterprise Linux or derivatives are supported
         DISTROVERSION="`distroversion|cut -d. -f1`"
         DISTROARCH="`arch`"
-        OSGRELEASE=current
+        # OSGRELEASE=current
+        # choose the release that includes GSI libraries, until LIGO
+        #   is completely switched over to tokens
+        OSGRELEASE=3.5/current
         if [ "$DISTROVERSION" = 6 ]; then
-            # choose last OSG release to support el6
+            # choose the last OSG release to support el6
             OSGRELEASE=3.4/current
         fi
         CVMFS_AUTHZ_OSG_WN_CLIENT="$OSGBASEDIR/$OSGRELEASE/el$DISTROVERSION-$DISTROARCH"


### PR DESCRIPTION
This cherry-picks #96 which uses the osg3.5 worker node client for missing cvmfs-x509-helper libraries for LIGO, rather than "current", because "current" will soon be pointing to osg3.6 which does not have some of the libraries (that is, the GSI libraries).

It also cherry-picks #97 which eliminates a wrapper process on cvmfs_scitoken_helper by calling exec.