### PR TITLE
invert computecanada URL logic to support more repos beyond soft

### DIFF
--- a/etc/cvmfs/config.d/restricted.computecanada.ca.conf
+++ b/etc/cvmfs/config.d/restricted.computecanada.ca.conf
@@ -1,0 +1,3 @@
+# The restricted.computecanada.ca repo can not be externally accessed, but is referenced by the public soft.computecanada.ca repo.
+# Use an invalid URL to prevent clients from futilely attempting to access it in the first place, to fail faster and reduce noise (HTTP 403) in the server logs.
+CVMFS_SERVER_URL="http://NULL"

--- a/etc/cvmfs/config.d/soft.computecanada.ca.conf
+++ b/etc/cvmfs/config.d/soft.computecanada.ca.conf
@@ -1,7 +1,0 @@
-# CVMFS_SERVER_URL defined here to avoid external use of other computecanada.ca repos
-if [ "$CVMFS_USE_CDN" = "yes" ] || [ "$CVMFS_HTTP_PROXY" = "DIRECT" ] || [ "$CVMFS_HTTP_PROXY" = "auto;DIRECT" ]; then
-  CVMFS_SERVER_URL="http://cvmfs-s1.computecanada.net/cvmfs/@fqrn@"
-  CVMFS_USE_GEOAPI=no
-else
-  CVMFS_SERVER_URL="http://cvmfs-s1-arbutus.computecanada.ca:8000/cvmfs/@fqrn@;http://cvmfs-s1-beluga.computecanada.ca:8000/cvmfs/@fqrn@;http://cvmfs-s1-east.computecanada.ca:8000/cvmfs/@fqrn@;http://cvmfs-s1.computecanada.net/cvmfs/@fqrn@"
-fi

--- a/etc/cvmfs/domain.d/computecanada.ca.conf
+++ b/etc/cvmfs/domain.d/computecanada.ca.conf
@@ -3,7 +3,12 @@ CVMFS_HTTP_PROXY="$CVMFS_HTTP_PROXY"
 CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 . ../common.conf
 
-# See CVMFS_SERVER_URL in ../config.d/soft.computecanada.ca.conf
+if [ "$CVMFS_USE_CDN" = "yes" ] || [ "$CVMFS_HTTP_PROXY" = "DIRECT" ] || [ "$CVMFS_HTTP_PROXY" = "auto;DIRECT" ]; then
+  CVMFS_SERVER_URL="http://cvmfs-s1.computecanada.net/cvmfs/@fqrn@"
+  CVMFS_USE_GEOAPI=no
+else
+  CVMFS_SERVER_URL="http://cvmfs-s1-arbutus.computecanada.ca:8000/cvmfs/@fqrn@;http://cvmfs-s1-beluga.computecanada.ca:8000/cvmfs/@fqrn@;http://cvmfs-s1-east.computecanada.ca:8000/cvmfs/@fqrn@;http://cvmfs-s1.computecanada.net/cvmfs/@fqrn@"
+fi
 
 CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/computecanada.ca
 CVMFS_USE_GEOAPI=yes


### PR DESCRIPTION
As contemplated in https://github.com/cvmfs-contrib/config-repo/pull/95, we anticipate having more repos of public interest.

So instead of only specifying soft, we set the URLs for all repos in the domain.d file, but block the restricted repo explicitly with a config.d file.

Please let me know when this is available with the testing tag  CVMFS_REPOSITORY_TAG=TESTING @jblomer .