### PR TITLE
Initial script to compare cache list against topology (SOFTWARE-3470)

### DIFF
--- a/checks/diff_cache_configs.py
+++ b/checks/diff_cache_configs.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+import re
+import os
+import json
+import collections
+import urllib.request
+from subprocess import Popen, PIPE
+
+CVMFS_EXTERNAL_URL = "CVMFS_EXTERNAL_URL"
+
+baseurl = "https://raw.githubusercontent.com/cvmfs-contrib/config-repo/master"
+ligoconf = "etc/cvmfs/config.d/ligo.osgstorage.org.conf"
+osgconf = "etc/cvmfs/domain.d/osgstorage.org.conf"
+
+namespaces = "https://topology.opensciencegrid.org/stashcache/namespaces.json"
+
+
+def slurp(url):
+    local = "%s/../%s" % (os.path.dirname(__file__), url)
+    if os.path.exists(local):
+        return open(local, "rb").read()
+    else:
+        remote = url if "://" in url else "%s/%s" % (baseurl, url) 
+        return urllib.request.urlopen(remote).read()
+
+
+def shell_parse_env(srctxt, env):
+    # evaluate shell source text and print the value of env var
+    env = env.encode()
+    # only eval lines that contain the env var we are interested in
+    grepped = b"\n".join( line for line in srctxt.splitlines() if env in line )
+    sh_code = 'eval "$1"; echo "${!2}"'
+    cmdline = ["/bin/bash", "-c", sh_code, "-", grepped, env]
+    sh_eval = Popen(cmdline, stdout=PIPE).communicate()[0] or b''
+    return sh_eval.decode()
+
+
+def get_conf_urls(confurl):
+    txt = slurp(confurl)
+    return shell_parse_env(txt, CVMFS_EXTERNAL_URL).strip().split(";")
+
+
+URLInfo = collections.namedtuple("URLInfo", ["proto", "hostport", "path"])
+
+def split_url_components(url):
+    #  "https://xrootd-local.unl.edu:1094//user/ligo/" ->
+    # ("https://", "xrootd-local.unl.edu:1094", "/user/ligo")
+    m = re.match(r'^(https?://)([^/]*)/?(/.*)', url)
+    return URLInfo(*m.groups()) if m else URLInfo(None, None, None)
+
+
+def get_conf_url_infos(confurl):
+    urls = get_conf_urls(confurl)
+    return list(map(split_url_components, urls))
+
+
+def get_conf_url_path_map(confurl):
+    urlinfos = get_conf_url_infos(confurl)
+    dd = collections.defaultdict(set)
+    for info in urlinfos:
+        dd[info.path].add(info.hostport)
+    return dd
+
+
+def cache_endpoints(caches, endpoint):
+    endpoints = set()
+    for cache in caches:
+        endpoints.add(cache[endpoint])
+    return endpoints
+
+
+def get_namespaces_map():
+    txt = slurp(namespaces)
+    d = json.loads(txt)
+    return {
+        ns['path']: {
+            'auth_endpoint': cache_endpoints(ns['caches'], 'auth_endpoint'),
+            'endpoint': cache_endpoints(ns['caches'], 'endpoint')
+        } for ns in d['namespaces']
+    }
+
+
+def do_conf_comparisons():
+    nsmap = get_namespaces_map()
+    osgmap = get_conf_url_path_map(osgconf)
+    ligomap = get_conf_url_path_map(ligoconf)
+
+    osg_cvmfs_caches = osgmap['/']
+    osg_topology_caches = nsmap['/osgconnect/public']['endpoint']
+
+    ligo_cvmfs_caches = ligomap['/user/ligo/']
+    ligo_topology_caches = nsmap['/user/ligo']['auth_endpoint']
+
+    osg_cvmfs_extra = osg_cvmfs_caches - osg_topology_caches
+    osg_cvmfs_missing = osg_topology_caches - osg_cvmfs_caches
+
+    print_diffs(osgconf, osg_cvmfs_caches, osg_topology_caches)
+    print_diffs(ligoconf, ligo_cvmfs_caches, ligo_topology_caches)
+
+
+def print_diffs(conf, cvmfs_caches, topology_caches):
+    conf = os.path.basename(conf)
+    if cvmfs_caches == topology_caches:
+        print("%s is up to date with topology source" % conf)
+        print("")
+    else:
+        cvmfs_missing = topology_caches - cvmfs_caches
+        cvmfs_extra   = cvmfs_caches    - topology_caches
+
+        if cvmfs_missing:
+            print("Missing items from %s (to add)" % conf)
+            print_bulletted(cvmfs_missing)
+            print("")
+        if cvmfs_extra:
+            print("Extra items in %s (to remove)" % conf)
+            print_bulletted(cvmfs_extra)
+            print("")
+
+
+def print_bulletted(items):
+    for item in sorted(items):
+        print(" - %s" % item)
+
+
+def main():
+    do_conf_comparisons()
+
+
+if __name__ == '__main__':
+    main()
+
+

--- a/checks/whitelist.txt
+++ b/checks/whitelist.txt
@@ -1,0 +1,1 @@
+# one item per line FQDN:port


### PR DESCRIPTION
Per [SOFTWARE-3470](https://jira.opensciencegrid.org/browse/SOFTWARE-3470), ideally we'll incorporate this into CI checks, and perhaps even auto-generate OASIS StashCache configs.



Current script output

```
$ ./diff_cache_configs.py 
Missing items from osgstorage.org.conf (to add)
 - fiona-r-uva.vlan7.uvalight.net:8000
 - hcc-stash.unl.edu:8000
 - helm-cache1.osgdev.chtc.io:8000
 - sc-cache.chtc.wisc.edu:8000
 - stash.farm.particle.cz:8000
 - stashcache.grid.uchicago.edu:8000
 - stashcache.gwave.ics.psu.edu:8000
 - stashcache.jinr.ru:8000
 - stashcache.uchicago.slateci.net:8000

Extra items in osgstorage.org.conf (to remove)
 - fiona.uvalight.net:8000

Missing items from ligo.osgstorage.org.conf (to add)
 - dtn2-daejeon.kreonet.net:8443
 - fiona-r-uva.vlan7.uvalight.net:8443
 - hcc-stash.unl.edu:8443
 - stashcache.gravity.cf.ac.uk:8443
 - stashcache.gwave.ics.psu.edu:8443
 - stashcache.t2.ucsd.edu:8443

Extra items in ligo.osgstorage.org.conf (to remove)
 - dtn2-daejeon.kreonet.net:8444
 - fiona.uvalight.net:8444
 - stashcache.gravity.cf.ac.uk:8444
 - stashcache.t2.ucsd.edu:8444
 - xrootd-local.unl.edu:1094
```
