### PR TITLE
Update ligo.osgstorage.org.conf

### DIFF
--- a/etc/cvmfs/config.d/ligo.osgstorage.org.conf
+++ b/etc/cvmfs/config.d/ligo.osgstorage.org.conf
@@ -1,7 +1,7 @@
 # subset of stashcache servers configured by OSG
-CVMFS_EXTERNAL_URL="https://stashcache.t2.ucsd.edu:8444//user/ligo/;https://osg-kansas-city-stashcache.nrp.internet2.edu:8444//user/ligo/;https://osg-chicago-stashcache.nrp.internet2.edu:8444//user/ligo/;https://osg-new-york-stashcache.nrp.internet2.edu:8444//user/ligo/;https://dtn2-daejeon.kreonet.net:8444//user/ligo/;https://ligo.hpc.swin.edu.au:8443//user/ligo/"
+CVMFS_EXTERNAL_URL="https://stashcache.t2.ucsd.edu:8443//user/ligo/;https://osg-kansas-city-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-chicago-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-new-york-stashcache.nrp.internet2.edu:8443//user/ligo/;https://dtn2-daejeon.kreonet.net:8443//user/ligo/;https://ligo.hpc.swin.edu.au:8443//user/ligo/"
 # stashcache servers not configured by OSG
-CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://fiona.uvalight.net:8444//user/ligo/;https://stashcache.gravity.cf.ac.uk:8444//user/ligo/;https://xcache.cr.cnaf.infn.it:8443//user/ligo/;https://xcachevirgo.pic.es:8443//user/ligo/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://fiona.uvalight.net:8443//user/ligo/;https://stashcache.gravity.cf.ac.uk:8443//user/ligo/;https://xcache.cr.cnaf.infn.it:8443//user/ligo/;https://xcachevirgo.pic.es:8443//user/ligo/"
 
 # need to set these to anything here to export them from this config file
 CVMFS_AUTHZ_OSG_BASE_DIR=


### PR DESCRIPTION
caches are using ports 8444 and 8443, setting the default port (8443)
I changed the config on caches, now they can provide auth files using ports 8444 and 8443. If we changed the config, the cache still work for both ports 8444 and 8443. After the config is applied, I will remove port 8444 from the PODs.