### PR TITLE
Update ligo.osgstorage.org.conf - unifying the OSG topology names with CVMFS caches

### DIFF
--- a/etc/cvmfs/config.d/ligo.osgstorage.org.conf
+++ b/etc/cvmfs/config.d/ligo.osgstorage.org.conf
@@ -1,7 +1,7 @@
 # stashcache servers configured by OSG
 CVMFS_EXTERNAL_URL="https://xrootd-local.unl.edu:1094//user/ligo/;https://stashcache.t2.ucsd.edu:8443//user/ligo/;https://its-condor-xrootd1.syr.edu:8443//user/ligo/;https://osg-kansas-city-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-chicago-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-new-york-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-gftp2.pace.gatech.edu:8443//user/ligo/;https://dtn2-daejeon.kreonet.net:8443//user/ligo/;https://osg-houston-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-sunnyvale-stashcache.nrp.internet2.edu:8443//user/ligo/;https://ligo.hpc.swin.edu.au:8443//user/ligo/"
 # extra stashcache servers not used by OSG
-CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://fiona.uvalight.net:8443//user/ligo/;https://stashcache.gravity.cf.ac.uk:8443//user/ligo/;https://xcache.cr.cnaf.infn.it:8443//user/ligo/;https://xcachevirgo.pic.es:8443//user/ligo/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://fiona-r-uva.vlan7.uvalight.net:8443//user/ligo/;https://stashcache.gravity.cf.ac.uk:8443//user/ligo/;https://xcache.cr.cnaf.infn.it:8443//user/ligo/;https://xcachevirgo.pic.es:8443//user/ligo/"
 
 # need to set these to anything here to export them from this config file
 CVMFS_AUTHZ_OSG_BASE_DIR=


### PR DESCRIPTION
Update ligo.osgstorage.org.conf - unifying the OSG topology names with CVMFS caches