### PR TITLE
Set cache offline and updating FQDN - Master branch

### DIFF
--- a/etc/cvmfs/config.d/ligo.osgstorage.org.conf
+++ b/etc/cvmfs/config.d/ligo.osgstorage.org.conf
@@ -1,7 +1,7 @@
 # stashcache servers configured by OSG
 CVMFS_EXTERNAL_URL="https://unl-cache.nationalresearchplatform.org:8443;https://xrootd-local.unl.edu:1094//user/ligo/;https://stashcache.t2.ucsd.edu:8443//user/ligo/;https://its-condor-xrootd1.syr.edu:8443//user/ligo/;https://osg-kansas-city-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-chicago-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-new-york-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-gftp2.pace.gatech.edu:8443//user/ligo/;https://dtn2-daejeon.kreonet.net:8443//user/ligo/;https://osg-houston-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-sunnyvale-stashcache.t2.ucsd.edu:8443//user/ligo/;https://ligo.hpc.swin.edu.au:8443//user/ligo/"
 # extra stashcache servers not used by OSG
-CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://fiona-r-uva.vlan7.uvalight.net:8443//user/ligo/;https://stashcache.gravity.cf.ac.uk:8443//user/ligo/;https://xcache.cr.cnaf.infn.it:8443//user/ligo/;https://xcachevirgo.pic.es:8443//user/ligo/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://daejeon-kreonet-net.nationalresearchplatform.org:8443//user/ligo/;https://xcachevirgo.pic.es:8443//user/ligo/"
 
 # need to set these to anything here to export them from this config file
 CVMFS_AUTHZ_OSG_BASE_DIR=

--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -18,7 +18,7 @@ CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/osgstora
 # stashcache servers configured by OSG
 CVMFS_EXTERNAL_URL="http://unl-cache.nationalresearchplatform.org:8000;http://stashcache.t2.ucsd.edu:8000/;http://its-condor-xrootd1.syr.edu:8000/;http://osg-kansas-city-stashcache.nrp.internet2.edu:8000/;http://osg-chicago-stashcache.nrp.internet2.edu:8000/;http://osg-new-york-stashcache.nrp.internet2.edu:8000/;http://stash-cache.osg.chtc.io:8000/;http://osg-gftp2.pace.gatech.edu:8000/;http://dtn2-daejeon.kreonet.net:8000/;http://osg-houston-stashcache.nrp.internet2.edu:8000/;http://osg-sunnyvale-stashcache.t2.ucsd.edu:8000/"
 # extra stashcache servers not used by OSG
-CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://fiona-r-uva.vlan7.uvalight.net:8000/;http://xcache.cr.cnaf.infn.it:8000/;http://xcachevirgo.pic.es:8000/;http://stashcache.edi.scotgrid.ac.uk:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://daejeon-kreonet-net.nationalresearchplatform.org:8000/;http://xcachevirgo.pic.es:8000/;http://stashcache.edi.scotgrid.ac.uk:8000/"
 CVMFS_EXTERNAL_MAX_SERVERS=4
 CVMFS_FOLLOW_REDIRECTS=yes
 CVMFS_QUOTA_LIMIT=1000


### PR DESCRIPTION
Removing due to maintenance: xcache.cr.cnaf.infn.it and stashcache.gravity.cf.ac.uk

 Updating the Korea cache name