### PR TITLE
Set cache offline and updating FQDN - cgi branch

### DIFF
--- a/etc/cvmfs/config.d/ligo.osgstorage.org.conf
+++ b/etc/cvmfs/config.d/ligo.osgstorage.org.conf
@@ -1,7 +1,7 @@
 # subset of stashcache servers configured by OSG
 CVMFS_EXTERNAL_URL="https://stashcache.t2.ucsd.edu:8443//user/ligo/;https://osg-kansas-city-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-chicago-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-new-york-stashcache.nrp.internet2.edu:8443//user/ligo/;https://daejeon-kreonet-net.nationalresearchplatform.org:8443//user/ligo/;https://ligo.hpc.swin.edu.au:8443//user/ligo/"
 # stashcache servers not configured by OSG
-CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://fiona-r-uva.vlan7.uvalight.net:8443//user/ligo/;https://stashcache.gravity.cf.ac.uk:8443//user/ligo/;https://xcache.cr.cnaf.infn.it:8443//user/ligo/;https://xcachevirgo.pic.es:8443//user/ligo/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://daejeon-kreonet-net.nationalresearchplatform.org:8443//user/ligo/;https://xcache.cr.cnaf.infn.it:8443//user/ligo/;https://xcachevirgo.pic.es:8443//user/ligo/"
 
 # need to set these to anything here to export them from this config file
 CVMFS_AUTHZ_OSG_BASE_DIR=


### PR DESCRIPTION
Removing due to maintenance: xcache.cr.cnaf.infn.it and stashcache.gravity.cf.ac.uk

Updating the Korea cache name