### PR TITLE
Set cache offline and update FQDN - EGI branch

### DIFF
--- a/etc/cvmfs/config.d/ligo.osgstorage.org.conf
+++ b/etc/cvmfs/config.d/ligo.osgstorage.org.conf
@@ -1,7 +1,7 @@
 # subset of stashcache servers configured by OSG
 CVMFS_EXTERNAL_URL="https://stashcache.t2.ucsd.edu:8443//user/ligo/;https://osg-kansas-city-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-chicago-stashcache.nrp.internet2.edu:8443//user/ligo/;https://osg-new-york-stashcache.nrp.internet2.edu:8443//user/ligo/;https://daejeon-kreonet-net.nationalresearchplatform.org:8443//user/ligo/;https://ligo.hpc.swin.edu.au:8443//user/ligo/"
 # stashcache servers not configured by OSG
-CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://fiona-r-uva.vlan7.uvalight.net:8443//user/ligo/;https://stashcache.gravity.cf.ac.uk:8443//user/ligo/;https://xcache.cr.cnaf.infn.it:8443//user/ligo/;https://xcachevirgo.pic.es:8443//user/ligo/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://fiona-r-uva.vlan7.uvalight.net:8443//user/ligo/;https://xcachevirgo.pic.es:8443//user/ligo/"
 
 # need to set these to anything here to export them from this config file
 CVMFS_AUTHZ_OSG_BASE_DIR=

--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -14,7 +14,7 @@ CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/osgstora
 # subset of stashcache servers configured by OSG
 CVMFS_EXTERNAL_URL="http://stashcache.t2.ucsd.edu:8000/;http://osg-kansas-city-stashcache.nrp.internet2.edu:8000/;http://osg-new-york-stashcache.nrp.internet2.edu:8000/;http://daejeon-kreonet-net.nationalresearchplatform.org:8000/"
 # stashcache servers not configured by OSG
-CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://fiona-r-uva.vlan7.uvalight.net:8000/;http://xcache.cr.cnaf.infn.it:8000/;http://xcachevirgo.pic.es:8000/;http://stashcache.edi.scotgrid.ac.uk:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://fiona-r-uva.vlan7.uvalight.net:8000/;http://xcachevirgo.pic.es:8000/;http://stashcache.edi.scotgrid.ac.uk:8000/"
 CVMFS_EXTERNAL_MAX_SERVERS=4
 CVMFS_FOLLOW_REDIRECTS=yes
 CVMFS_QUOTA_LIMIT=1000


### PR DESCRIPTION
Removing due to maintenance: xcache.cr.cnaf.infn.it and stashcache.gravity.cf.ac.uk

Updating the Korea cache name: daejeon-kreonet-net.nationalresearchplatform.org