### PR TITLE
Bring osgstorage.org.conf up to date with egi branch

### DIFF
--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -13,9 +13,19 @@ CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/osgstora
 CVMFS_USE_GEOAPI=yes
 CVMFS_SEND_INFO_HEADER=yes
 
-CVMFS_EXTERNAL_URL="http://stashcache.t2.ucsd.edu:8000/;http://osg-kansas-city-stashcache.nrp.internet2.edu:8000/;http://osg-new-york-stashcache.nrp.internet2.edu:8000/;http://dtn2-daejeon.kreonet.net:8000/"
-# stashcache servers not configured by OSG
-CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osg-stash-sfu-computecanada-ca.nationalresearchplatform.org:8000/;http://fiona-r-uva.vlan7.uvalight.net:8000/;http://xcache.cr.cnaf.infn.it:8000/;http://xcachevirgo.pic.es:8000/;http://stashcache.edi.scotgrid.ac.uk:8000/"
+# subset of OSDF caches used by OSG
+CVMFS_EXTERNAL_URL="http://stashcache.t2.ucsd.edu:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osg-kansas-city-stashcache.nrp.internet2.edu:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osg-chicago-stashcache.nrp.internet2.edu:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osg-new-york-stashcache.nrp.internet2.edu:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://daejeon-kreonet-net.nationalresearchplatform.org:8000/"
+# OSDF caches not configured by OSG
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://cf-ac-uk-cache.nationalresearchplatform.org:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osg-stash-sfu-computecanada-ca.nationalresearchplatform.org:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://fiona-r-uva.vlan7.uvalight.net:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://xcachevirgo.pic.es:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://stashcache.edi.scotgrid.ac.uk:8000/"
+
 CVMFS_EXTERNAL_MAX_SERVERS=4
 CVMFS_FOLLOW_REDIRECTS=yes
 CVMFS_QUOTA_LIMIT=1000


### PR DESCRIPTION
This brings the list of OSDF caches in osgstorage.org.conf in sync with the current egi branch, as updated in #168.