### PR TITLE
Add sampa stratum 1 (default)

### DIFF
--- a/etc/cvmfs/domain.d/cern.ch.conf
+++ b/etc/cvmfs/domain.d/cern.ch.conf
@@ -6,9 +6,9 @@ CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 # The cvmfs-config-default package has this variable turned off by default.
 # Users can turn it on the default.local file
 if [ "$CVMFS_USE_CDN" = "yes" ]; then
-    CVMFS_SERVER_URL="http://s1cern-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://s1cern-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1sampa-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
 else
-    CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch:8000/cvmfs/@fqrn@;http://cernvmfs.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch:8000/cvmfs/@fqrn@;http://cernvmfs.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@;http://sampacs01.if.usp.br:8000/cvmfs/@fqrn@"
 fi
 CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/cern.ch
 CVMFS_USE_GEOAPI=yes

--- a/etc/cvmfs/domain.d/egi.eu.conf
+++ b/etc/cvmfs/domain.d/egi.eu.conf
@@ -6,9 +6,9 @@ CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 # The cvmfs-config-default package has this variable turned off by default.
 # Users can turn it on the default.local file
 if [ "$CVMFS_USE_CDN" = "yes" ]; then
-    CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1triumf-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1triumf-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1sampa-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
 else
-    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@;http://sampacs01.if.usp.br:8000/cvmfs/@fqrn@"
 fi
 CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/egi.eu
 CVMFS_USE_GEOAPI=yes

--- a/etc/cvmfs/domain.d/hsf.org.conf
+++ b/etc/cvmfs/domain.d/hsf.org.conf
@@ -6,9 +6,9 @@ CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 # The cvmfs-config-default package has this variable turned off by default.
 # Users can turn it on the default.local file
 if [ "$CVMFS_USE_CDN" = "yes" ]; then
-    CVMFS_SERVER_URL="http://s1cern-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://s1cern-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1sampa-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
 else
-    CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch:8000/cvmfs/@fqrn@;http://cernvmfs.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch:8000/cvmfs/@fqrn@;http://cernvmfs.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@;http://sampacs01.if.usp.br:8000/cvmfs/@fqrn@"
 fi
 CVMFS_KEYS_DIR="$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/hsf.org"
 CVMFS_USE_GEOAPI=yes

--- a/etc/cvmfs/domain.d/kek.jp.conf
+++ b/etc/cvmfs/domain.d/kek.jp.conf
@@ -5,9 +5,9 @@ CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 . ../common.conf
 
 if [ "$CVMFS_USE_CDN" = "yes" ]; then
-    CVMFS_SERVER_URL="http://s1kek-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1desy-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://s1kek-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1desy-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1sampa-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
 else
-    CVMFS_SERVER_URL="http://cvmfs-stratum-one.cc.kek.jp:8000/cvmfs/@fqrn@;http://cernvmfs.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://grid-cvmfs-one.desy.de:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://cvmfs-stratum-one.cc.kek.jp:8000/cvmfs/@fqrn@;http://cernvmfs.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://grid-cvmfs-one.desy.de:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@;http://sampacs01.if.usp.br:8000/cvmfs/@fqrn@"
 fi
 CVMFS_KEYS_DIR="$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/kek.jp"
 CVMFS_USE_GEOAPI=yes

--- a/etc/cvmfs/domain.d/opensciencegrid.org.conf
+++ b/etc/cvmfs/domain.d/opensciencegrid.org.conf
@@ -6,9 +6,9 @@ CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 # The cvmfs-config-default package has this variable turned off by default.
 # Users can turn it on the default.local file
 if [ "$CVMFS_USE_CDN" = "yes" ]; then
-    CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1sampa-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
 else
-    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@;http://sampacs01.if.usp.br:8000/cvmfs/@fqrn@"
 fi
 CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/opensciencegrid.org
 CVMFS_USE_GEOAPI=yes

--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -5,9 +5,9 @@ CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 . ../common.conf
 
 if [ "$CVMFS_USE_CDN" = "yes" ]; then
-    CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1osggoc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1osggoc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1sampa-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
 else
-    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1goc.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1goc.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@;http://sampacs01.if.usp.br:8000/cvmfs/@fqrn@"
 fi
 CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/osgstorage.org
 CVMFS_USE_GEOAPI=yes


### PR DESCRIPTION
This adds to the default branch the newly fully populated SAMPA stratum 1 as a source for CERN, EGI, HSF, IGWN (via symlinks to OSG config), KEK, and OSG.  It is a cherry-pick of #174 except leaving out DESY since it was not included in the default branch.