### PR TITLE
Optimize open file descriptor settings for ALICE (default)

### DIFF
--- a/etc/cvmfs/config.d/alice.cern.ch.conf
+++ b/etc/cvmfs/config.d/alice.cern.ch.conf
@@ -3,4 +3,12 @@
 # On many-core nodes, this can overflow the 128k default limit for cvmfs
 # processes.
 # See https://github.com/cvmfs/cvmfs/issues/3067 for details.
-CVMFS_NFILES=262144
+if [ -z $CVMFS_NFILES ] || [ $CVMFS_NFILES -lt 524288 ]; then
+  CVMFS_NFILES=524288
+fi
+
+# As of cvmfs 2.11, the refcounted cache manager keeps the number of open
+# file descriptors of the cvmfs2 process under control.
+# Note: we are gradually rolling out this setting, starting with the ALICE
+# repository. This setting is intended to be the future default.
+CVMFS_CACHE_REFCOUNT=true


### PR DESCRIPTION
This cherry-picks #196 from the master to the default branch.