### PR TITLE
Update for the new current osg-wn-client from el7 to el8 for portable files

### DIFF
--- a/etc/cvmfs/osgstorage-auth.conf
+++ b/etc/cvmfs/osgstorage-auth.conf
@@ -80,7 +80,7 @@ if [ ! -f /etc/grid-security/certificates/cilogon-basic.pem ] || \
     if $CVMFS_X509_AUTHZ_LIBS_VALID; then
         # the needed libraries are already installed
         # we'll only use portable files, so pick any osg-wn-client
-        CVMFS_AUTHZ_OSG_BASE_DIR="$OSGBASEDIR/current/el7-x86_64"
+        CVMFS_AUTHZ_OSG_BASE_DIR="$OSGBASEDIR/current/el8-x86_64"
     else
         # we'll use both libraries and portable files
         # only Redhat Enterprise Linux or derivatives are supported


### PR DESCRIPTION
such as the CA certificates.