### PR TITLE
reduce warnings/failures for sft-nightlies repo

### DIFF
--- a/etc/cvmfs/config.d/sft-nightlies.cern.ch.conf
+++ b/etc/cvmfs/config.d/sft-nightlies.cern.ch.conf
@@ -1,0 +1,5 @@
+if [ "$CVMFS_USE_CDN" = "yes" ]; then
+    CVMFS_SERVER_URL="http://s1cern-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@"
+else
+    CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@;http://cvmfs.sdcc.bnl.gov:8000/cvmfs/@fqrn@"
+fi


### PR DESCRIPTION
Based on https://cvmfs-monitor-frontend.web.cern.ch/sft-nightlies.cern.ch  and the atlas-nightlies.cern.ch.conf file.

According to my tests it avoids all the "failed to access" warnings because this repo is not hosted on all servers.