### PR TITLE
Add CNAF cache for authorised CVMFS repos (egi)

### DIFF
--- a/etc/cvmfs/osgstorage-auth.conf
+++ b/etc/cvmfs/osgstorage-auth.conf
@@ -24,6 +24,7 @@ CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://osg-stash-sfu-computecanada-ca.n
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://fiona-r-uva.vlan7.uvalight.net:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://xcachevirgo.pic.es:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://stashcache.jinr.ru:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://ds-914.cr.cnaf.infn.it:8443/"
 
 
 distroversion()


### PR DESCRIPTION
This PR presents the minimal change that closes #221 by adding the CNAF cache to the `CVMFS_EXTERNAL_URL` list for authorised CVMFS repos.

cc @merl1n0