### PR TITLE
adding back the cf-ac-uk-cache.nationalresearchplatform.org (egi)

### DIFF
--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -33,6 +33,7 @@ CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://stashcache.jinr.ru:8000/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://stashcache-edi-scotgrid-ac-uk.nationalresearchplatform.org:8000/"
 # OSDF caches not configured by OSG
 #Europe
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://cf-ac-uk-cache.nationalresearchplatform.org:8000/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://stash.farm.particle.cz:8000/"
 
 CVMFS_EXTERNAL_MAX_SERVERS=4


### PR DESCRIPTION
adding back the cf-ac-uk-cache.nationalresearchplatform.org