### PR TITLE
Add sampa stratum1 to atlas-nightlies and sft-nightlies (default)

### DIFF
--- a/etc/cvmfs/config.d/atlas-nightlies.cern.ch.conf
+++ b/etc/cvmfs/config.d/atlas-nightlies.cern.ch.conf
@@ -1,5 +1,5 @@
 if [ "$CVMFS_USE_CDN" = "yes" ]; then
-    CVMFS_SERVER_URL="http://s1cern-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://s1cern-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1sampa-cvmfs.openhtc.io/cvmfs/@fqrn@"
 else
-    CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://sampacs01.if.usp.br:8000/cvmfs/@fqrn@"
 fi

--- a/etc/cvmfs/config.d/sft-nightlies.cern.ch.conf
+++ b/etc/cvmfs/config.d/sft-nightlies.cern.ch.conf
@@ -1,5 +1,6 @@
 if [ "$CVMFS_USE_CDN" = "yes" ]; then
-    CVMFS_SERVER_URL="http://s1cern-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://s1cern-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1sampa-cvmfs.openhtc.io/cvmfs/@fqrn@"
 else
-    CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@;http://cvmfs.sdcc.bnl.gov:8000/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://sampacs01.if.usp.br:8000/cvmfs/@fqrn@"
 fi
+


### PR DESCRIPTION
The sampa stratum1 is also hosting {atlas|sft}-nightlies.cern.ch so we might as well add them.