### PR TITLE
Enable streaming cache management for external data when available

### DIFF
--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -50,6 +50,8 @@ CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://stashcache-edi-scotgrid-ac-uk.nat
 
 CVMFS_EXTERNAL_MAX_SERVERS=4
 CVMFS_FOLLOW_REDIRECTS=yes
+CVMFS_LOW_SPEED_LIMIT=512
 CVMFS_QUOTA_LIMIT=1000
 CVMFS_CACHE_BASE="$CVMFS_CACHE_BASE/osgstorage"
-CVMFS_LOW_SPEED_LIMIT=512
+# This option avoids caching external data at all with cvmfs clients >= 2.11.0
+CVMFS_STREAMING_CACHE=yes


### PR DESCRIPTION
This enables a [new cvmfs client feature](https://cvmfs.readthedocs.io/en/2.11/cpt-configure.html#streaming-cache-manager) introduced in version 2.11.0.  Let's try it just in the osg configuration repo for a while and see how it behaves.