### PR TITLE
Fixing host name amst-fiona.nationalresearchplatform.org (osg)

### DIFF
--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -43,7 +43,7 @@ CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://singapore.nationalresearchplatfor
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://ligo.hpc.swin.edu.au:8000/"
 #Europe
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://amst-osdf-xcache01.es.net:8443/"
-CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://fiona-r-uva.vlan7.uvalight.net:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://amst-fiona.nationalresearchplatform.org:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://lond-osdf-xcache01.es.net:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://stashcache-edi-scotgrid-ac-uk.nationalresearchplatform.org:8000/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://xcachevirgo.pic.es:8000/"

--- a/etc/cvmfs/osgstorage-auth.conf
+++ b/etc/cvmfs/osgstorage-auth.conf
@@ -38,7 +38,7 @@ CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://amst-osdf-xcache01.es.net:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://lond-osdf-xcache01.es.net:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://ds-914.cr.cnaf.infn.it:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://stashcache-edi-scotgrid-ac-uk.nationalresearchplatform.org:8443/"
-CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://fiona-r-uva.vlan7.uvalight.net:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://amst-fiona.nationalresearchplatform.org:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://stashcache.jinr.ru:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;https://xcachevirgo.pic.es:8443/"
 # Oceania


### PR DESCRIPTION
from fiona-r-uva.vlan7.uvalight.net to amst-fiona.nationalresearchplatform.org.  Cherry-pick of #291 to the osg branch.