### PR TITLE
Use $RANDOM % 2 instead of $$ % 2 to avoid unbalance in pid namespaces (osg)

### DIFF
--- a/etc/cvmfs/default.conf
+++ b/etc/cvmfs/default.conf
@@ -1,7 +1,7 @@
 if [ -z "$CVMFS_PAC_URLS" ] || [ "$CVMFS_PAC_URLS" = "http://wpad/wpad.dat" ]; then
   # Set default list of proxy auto config urls if not set before this in
   #  in an /etc/cvmfs/default.d file.
-  if [ "$(($$ % 2))" -eq 1 ]; then
+  if [ "$((RANDOM % 2))" -eq 1 ]; then
     CVMFS_PAC_URLS="http://grid-wpad/wpad.dat;http://wpad/wpad.dat;http://cernvm-wpad.fnal.gov/wpad.dat;http://cernvm-wpad.cern.ch/wpad.dat"
   else
     CVMFS_PAC_URLS="http://grid-wpad/wpad.dat;http://wpad/wpad.dat;http://cernvm-wpad.cern.ch/wpad.dat;http://cernvm-wpad.fnal.gov/wpad.dat"


### PR DESCRIPTION
Cherry-pick #298 to the osg branch.