### PR TITLE
When WPAD is enabled and CVMFS_USE_CDN is unset, set the latter to yes

### DIFF
--- a/etc/cvmfs/common.conf
+++ b/etc/cvmfs/common.conf
@@ -17,3 +17,9 @@ elif [ "$CVMFS_CLIENT_PROFILE" != "custom" ]; then
     CVMFS_FALLBACK_PROXY="http://cvmfsbproxy.cern.ch:3126;http://cvmfsbproxy.fnal.gov:3126"
   fi
 fi
+
+if [ -z "$CVMFS_USE_CDN" ] && [ "$CVMFS_HTTP_PROXY" = "auto;DIRECT" ]; then
+    # WPAD when there's no squid found doesn't work unless using the CDN
+    CVMFS_USE_CDN=yes
+  fi
+fi


### PR DESCRIPTION
See discussion in the [forum](https://cernvm-forum.cern.ch/t/cvmfs-unusable-from-cold-cache/546/10).

The osg & egi branches already do this and also if `CVMFS_HTTP_PROXY=DIRECT`, but @jblomer didn't want the DIRECT setting to go to the CDN by default.  If I recall correctly, that was the reason for the introduction of `CVMFS_CLIENT_PROFILE=single`.  However, the WPAD default response (when no squid is found) only works when the CDN is used.