### PR TITLE
add CDN servers for EESSI, use eessi.science CNAME for RAL Stratum 1 (egi)

### DIFF
--- a/etc/cvmfs/domain.d/eessi.io.conf
+++ b/etc/cvmfs/domain.d/eessi.io.conf
@@ -1,10 +1,15 @@
 # These are here so cvmfs will notice them if common.conf sets them
+CVMFS_USE_CDN="$CVMFS_USE_CDN"
 CVMFS_HTTP_PROXY="$CVMFS_HTTP_PROXY"
 CVMFS_FALLBACK_PROXY="$CVMFS_FALLBACK_PROXY"
 . ../common.conf
 
 # Stratum 1 servers for the eessi.io domain
-CVMFS_SERVER_URL="http://aws-eu-central-s1.eessi.science/cvmfs/@fqrn@;http://azure-us-east-s1.eessi.science/cvmfs/@fqrn@;http://cvmfs-ext.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@"
+if [ "$CVMFS_USE_CDN" = "yes" ]; then
+    CVMFS_SERVER_URL="http://s1eessieu1-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1eessina1-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@"
+else
+    CVMFS_SERVER_URL="http://aws-eu-central-s1.eessi.science/cvmfs/@fqrn@;http://azure-us-east-s1.eessi.science/cvmfs/@fqrn@;http://ral-uk-s1.eessi.science:8000/cvmfs/@fqrn@"
+fi
 
 # Public keys for the eessi.io domain
 CVMFS_KEYS_DIR="$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/eessi.io"


### PR DESCRIPTION
Same changes as in https://github.com/cvmfs-contrib/config-repo/pull/330, but now for the egi branch.