### PR TITLE
SOFTWARE-6275 Remove retired IGWN CVMFS repos

### DIFF
--- a/etc/cvmfs/config.d/kagra.storage.igwn.org.conf
+++ b/etc/cvmfs/config.d/kagra.storage.igwn.org.conf
@@ -1,1 +1,0 @@
-../osgstorage-auth.conf

--- a/etc/cvmfs/config.d/ligo-test.storage.igwn.org.conf
+++ b/etc/cvmfs/config.d/ligo-test.storage.igwn.org.conf
@@ -1,1 +1,0 @@
-../osgstorage-auth.conf

--- a/etc/cvmfs/config.d/ligo.osgstorage.org.conf
+++ b/etc/cvmfs/config.d/ligo.osgstorage.org.conf
@@ -1,8 +1,0 @@
-# need to set these to anything here to export them from this config file
-CVMFS_AUTHZ_CVMFS_TOKEN_VARNAME=
-X509_CERT_DIR=
-CVMFS_MAX_RETRIES=
-. $CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/osgstorage-auth.conf
-
-# add /user/ligo onto each external server URL
-CVMFS_EXTERNAL_URL="`echo "$CVMFS_EXTERNAL_URL;"|sed -e 's,;,/user/ligo;,g' -e 's,;$,,'`"

--- a/etc/cvmfs/config.d/ligo.storage.igwn.org.conf
+++ b/etc/cvmfs/config.d/ligo.storage.igwn.org.conf
@@ -1,1 +1,0 @@
-../osgstorage-auth.conf

--- a/etc/cvmfs/config.d/shared.storage.igwn.org.conf
+++ b/etc/cvmfs/config.d/shared.storage.igwn.org.conf
@@ -1,1 +1,0 @@
-../osgstorage-auth.conf

--- a/etc/cvmfs/config.d/virgo.storage.igwn.org.conf
+++ b/etc/cvmfs/config.d/virgo.storage.igwn.org.conf
@@ -1,1 +1,0 @@
-../osgstorage-auth.conf

--- a/etc/cvmfs/domain.d/storage.igwn.org.conf
+++ b/etc/cvmfs/domain.d/storage.igwn.org.conf
@@ -1,1 +1,0 @@
-osgstorage.org.conf

--- a/etc/cvmfs/keys/storage.igwn.org/opensciencegrid.org.pub
+++ b/etc/cvmfs/keys/storage.igwn.org/opensciencegrid.org.pub
@@ -1,1 +1,0 @@
-../opensciencegrid.org/opensciencegrid.org.pub


### PR DESCRIPTION
Per @josh-willis (many moons ago), these repos are retired:
```
/cvmfs/ligo.storage.igwn.org/
/cvmfs/shared.storage.igwn.org/
/cvmfs/virgo.storage.igwn.org/
/cvmfs/kagra.storage.igwn.org/
/cvmfs/ligo-test.storage.igwn.org/
```
(`/cvmfs/software.igwn.org` and `/cvmfs/gwosc.osgstorage.org` should remain, though these do not seem to be referenced here.)

[OSG SOFTWARE Jira link](https://opensciencegrid.atlassian.net/browse/SOFTWARE-6275)