### PR TITLE
Add remaining U.S. OSDF caches (default)

### DIFF
--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -13,14 +13,27 @@ CVMFS_KEYS_DIR=$CVMFS_MOUNT_DIR/$CVMFS_CONFIG_REPOSITORY/etc/cvmfs/keys/osgstora
 CVMFS_USE_GEOAPI=yes
 CVMFS_SEND_INFO_HEADER=yes
 
-# subset of OSDF caches used by OSG
+# OSDF caches used by OSG
 # North America
 CVMFS_EXTERNAL_URL="http://stashcache.t2.ucsd.edu:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://dtn-pas.bois.nrp.internet2.edu:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://dtn-pas.cinc.nrp.internet2.edu:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://dtn-pas.denv.nrp.internet2.edu:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://dtn-pas.hous.nrp.internet2.edu:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://dtn-pas.jack.nrp.internet2.edu:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://unl-cache.nationalresearchplatform.org:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://dtn-pas.kans.net.internet2.edu:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osdf1.chic.nrp.internet2.edu:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osg-new-york-stashcache.nrp.internet2.edu:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://mghpcc-cache.nationalresearchplatform.org:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://its-condor-xrootd1.syr.edu:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osg-gftp2.pace.gatech.edu:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osg-houston-stashcache.nrp.internet2.edu:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osg-sunnyvale-stashcache.nrp.internet2.edu:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://sdsc-cache.nationalresearchplatform.org:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osg-stash-sfu-computecanada-ca.nationalresearchplatform.org:8443/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://stashcache.ligo.caltech.edu:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osg-hawk-cache.cc.lehigh.edu:8000/"
 # South America
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://osdf-cache.sprace.org.br:8443/"
 # Asia
@@ -34,6 +47,7 @@ CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://amst-fiona.nationalresearchplatfo
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://lond-osdf-xcache01.es.net:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://stashcache-edi-scotgrid-ac-uk.nationalresearchplatform.org:8000/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://xcachevirgo.pic.es:8000/"
+
 # OSDF caches not configured by OSG
 #Europe
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://cf-ac-uk-cache.nationalresearchplatform.org:8443/"


### PR DESCRIPTION
The egi configuration repository configures only a subset of the Open Science Data Federation (OSDF) caches in the U.S., because people are expected to use the osg configuration there.  For the default configuration repository we have included the same subset as egi, under the assumption that people in the U.S. do not use cvmfs-config-default.  I have now found evidence that that assumption is wrong.  In particular, the Perlmutter HPC at NERSC has a good reason to use the default rpm, because it is a SUSE system and the OSG does not build SUSE rpms.  It's true that cvmfs-config rpms only include portable files, but still it's easy to see why system administrators would be reluctant to install elX rpms on a SUSE system.  There are very likely other installations in the U.S. that are also using cvmfs-config-default for various other reasons (including just not knowing which one they should use).

Instead, this PR increases the list of OSDF caches in osgstorage.org.conf to match the master branch which contained the superset of those listed by osg and egi.