### PR TITLE
Update port of stashcache-edi-scotgrid-ac-uk (egi)

### DIFF
--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -30,7 +30,7 @@ CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://ligo.hpc.swin.edu.au:8000/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://amst-osdf-xcache01.es.net:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://amst-fiona.nationalresearchplatform.org:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://lond-osdf-xcache01.es.net:8443/"
-CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://stashcache-edi-scotgrid-ac-uk.nationalresearchplatform.org:8000/"
+CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://stashcache-edi-scotgrid-ac-uk.nationalresearchplatform.org:8443/"
 CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://xcachevirgo.pic.es:8000/"
 # OSDF caches not configured by OSG
 #Europe


### PR DESCRIPTION
The server was transitioned from stashcache-based to Pelican-based, and listens on 8443 now.

( https://support.opensciencegrid.org/a/tickets/82860 )

Cherry-picked from #344 