### PR TITLE
Use streaming cache for osgstorage.org when client is new enough

### DIFF
--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -52,5 +52,13 @@ CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://xcachevirgo.pic.es:8000/"
 CVMFS_EXTERNAL_MAX_SERVERS=5
 CVMFS_FOLLOW_REDIRECTS=yes
 CVMFS_LOW_SPEED_LIMIT=512
-CVMFS_QUOTA_LIMIT=1000
-CVMFS_CACHE_BASE="$CVMFS_CACHE_BASE/osgstorage"
+
+if [ -n "$CVMFS_VERSION_NUMERIC" ] && [ "$CVMFS_VERSION_NUMERIC" -ge 21303 ]; then
+    # The client is a new enough version for this feature to work
+    # This feature avoids using a local cache for data in these repositories
+    CVMFS_STREAMING_CACHE=yes
+else
+    # Go back to the old way of reserving a small 1GB cache
+    CVMFS_QUOTA_LIMIT=1000
+    CVMFS_CACHE_BASE="$CVMFS_CACHE_BASE/osgstorage"
+fi


### PR DESCRIPTION
This has been tested for quite a while now on sbnd.osgstorage.org on Fermilab worker nodes and has been working fine.

Refer to #267 for the history of this feature.  Because it was broken in older client versions, enabling this needed to wait until the client version became available in a configuration variable, which happened in 2.13.3.