### PR TITLE
Revert "use streaming cache for osgstorage.org when client is new enough

### DIFF
--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -52,13 +52,5 @@ CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://xcachevirgo.pic.es:8000/"
 CVMFS_EXTERNAL_MAX_SERVERS=5
 CVMFS_FOLLOW_REDIRECTS=yes
 CVMFS_LOW_SPEED_LIMIT=512
-
-if [ -n "$CVMFS_VERSION_NUMERIC" ] && [ "$CVMFS_VERSION_NUMERIC" -ge 21303 ]; then
-    # The client is a new enough version for this feature to work
-    # This feature avoids using a local cache for data in these repositories
-    CVMFS_STREAMING_CACHE=yes
-else
-    # Go back to the old way of reserving a small 1GB cache
-    CVMFS_QUOTA_LIMIT=1000
-    CVMFS_CACHE_BASE="$CVMFS_CACHE_BASE/osgstorage"
-fi
+CVMFS_QUOTA_LIMIT=1000
+CVMFS_CACHE_BASE="$CVMFS_CACHE_BASE/osgstorage"


### PR DESCRIPTION
This reverts #348 because at least on some sites it allocates excessive memory.  See cvmfs/cvmfs#4318.