### PR TITLE
Enable streaming cache in osgstorage.org repos but limit file descriptors (osg)

### DIFF
--- a/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -52,5 +52,18 @@ CVMFS_EXTERNAL_URL="$CVMFS_EXTERNAL_URL;http://xcachevirgo.pic.es:8000/"
 CVMFS_EXTERNAL_MAX_SERVERS=5
 CVMFS_FOLLOW_REDIRECTS=yes
 CVMFS_LOW_SPEED_LIMIT=512
-CVMFS_QUOTA_LIMIT=1000
-CVMFS_CACHE_BASE="$CVMFS_CACHE_BASE/osgstorage"
+
+if [ -n "$CVMFS_VERSION_NUMERIC" ] && [ "$CVMFS_VERSION_NUMERIC" -ge 21303 ]; then
+    # The client is a new enough version for this feature to work
+    # This feature avoids using a local cache for data in these repositories
+    CVMFS_STREAMING_CACHE=yes
+    # However, the implementation allocates about 100 bytes per defined
+    # file descriptor, so make sure that's at a reasonable limit
+    if [ "$CVMFS_NFILES" -gt 131072 ]; then
+        CVMFS_NFILES=131072
+    fi
+else
+    # Go back to the old way of reserving a small 1GB cache
+    CVMFS_QUOTA_LIMIT=1000
+    CVMFS_CACHE_BASE="$CVMFS_CACHE_BASE/osgstorage"
+fi


### PR DESCRIPTION
This reintroduces the streaming cache from #348 but limits CVMFS_NFILES to 131072 (2^17, the default from `/etc/cvmfs/default.conf`) to avoid memory usage explosion.